### PR TITLE
Removed "footer" from the interpolation description

### DIFF
--- a/src/content/docs/10-getting-started/50-migration-guide.mdx
+++ b/src/content/docs/10-getting-started/50-migration-guide.mdx
@@ -225,7 +225,7 @@ to **nested translation objects**, addressing a limitation present in previous v
 
 When using a key like `main` that contains translations for subkeys such as
 `main.title`, and `main.text` the returned object will include
-the keys `title`, `text`, and `footer`.
+the keys `title` and  `text`.
 
 ~~~json title="en.json"
 {


### PR DESCRIPTION
Key doesn't exist in the example