### PR TITLE
docs(02-faq.md): fakeLoader usage

### DIFF
--- a/src/content/docs/40-resources/02-faq.md
+++ b/src/content/docs/40-resources/02-faq.md
@@ -204,7 +204,7 @@ triggers [`onTranslationChange`](/reference/translate-service-api/#ontranslation
 TestBed.configureTestingModule({
   providers: [
     provideTranslateService({
-      loader: provideTranslateLoader(() => new FakeLoader())
+      loader: provideTranslateLoader(FakeLoader)
     })
   ]
 });


### PR DESCRIPTION
Tested it locally, `() => new FakeLoader()` is incorrect.

Note: a global fakeLoader need to be created in the project himself

```typescript
const translations: TranslationObject = { TEST: 'This is a test' }
const fakeTranslation: TranslationObject = { NOT_USED: 'not used' }

@Injectable()
export class FakeLoader implements TranslateLoader {
  getTranslation(lang: string): Observable<TranslationObject> {
    if (lang === 'fake') {
      return of(fakeTranslation)
    }

    return of(translations)
  }
}
```